### PR TITLE
fix(dockerfile): remove deprecated maintainer instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-MAINTAINER Azure App Service Container Images <appsvc-images@microsoft.com>
+LABEL maintainer="Azure App Service Container Images <appsvc-images@microsoft.com>"
 RUN apt-get update -y
 RUN apt-get install -y python-pip python-dev build-essential
 COPY . /app


### PR DESCRIPTION
The`MAINTAINER` instruction from Dockerfile since it's deprecated. 
Replace the instruction with `LABEL` instead.

See: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated