### PR TITLE
Improves Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 FROM ubuntu:16.04
 MAINTAINER Azure App Service Container Images <appsvc-images@microsoft.com>
-RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-COPY . /app
+
+RUN apt-get update -y && /
+	apt-get install -y python-pip python-dev build-essential
+
+RUN mkdir /app
 WORKDIR /app
+
+COPY requirements.txt /app
 RUN pip install -r requirements.txt
+
+COPY . /app
+
 ENTRYPOINT ["python"]
 EXPOSE 5000
 CMD ["runserver.py"]


### PR DESCRIPTION
The dockerfile does not follow the best practices with respect to caching.

The requirements.txt should be copied first and the environment be set up.

This helps in scenarios when the project dependencies don't change but the
code changes. Before this commit, all the layers would have run resulting
in slower build times.